### PR TITLE
[FIX] Default to any ipv4

### DIFF
--- a/setup/main.js
+++ b/setup/main.js
@@ -97,4 +97,4 @@ http.createServer((request, response) => {
         response.writeHead(200);
         response.end("{\"message\": \"ok\"}");
     });
-}).listen(7312, "127.0.0.1");
+}).listen(7312, "0.0.0.0");


### PR DESCRIPTION
Most local development in php is often ran inside a docker container, binding the electron http server to 127.0.0.1 means messages are never received, Ideally this would be a cli option when launching the quo app.

#### Proposed solution/change

Setting to `0.0.0.0` to listen to any IPv4 in the short term would allow messages to be received from local and docker environments.
